### PR TITLE
Fix the go test failed because of the TestForkbomb

### DIFF
--- a/tasks/forkbomb.task
+++ b/tasks/forkbomb.task
@@ -2,7 +2,7 @@
   "environment": "busybox",
   "taskfs": "forkbomb.sfs",
   "limits": {
-    "time": 60,
+    "time": 90,
     "memory": 32,
     "disk": 50,
     "output": 1024

--- a/tasks/forkbomb/run.sh
+++ b/tasks/forkbomb/run.sh
@@ -1,7 +1,26 @@
 #!/bin/sh
 echo "Start"
+
 bomb() {
-    bomb | bomb &
+    bomb 2> /dev/null | bomb 2> /dev/null &
 }
 bomb
-echo "Done"
+sleep 1 # Wait for forkbomb to propagate
+
+# We can't use pipe because we don't have any process available. 
+# It's all taken by the bomb.
+
+# We could use pgrep but it will enlarge the VM for nothing.
+ps > /tmp/process.log
+grep run.sh /tmp/process.log > /tmp/bomb.log
+
+# Count the number of lines (i.e the number of bombs) in bomb.log.
+wc -l /tmp/bomb.log > /tmp/bomb.count
+# The output of $(wc -l bomb.log) give something like: "99 /tmp/bomb.log".
+# We need to parse this output to just have the number of bombs.
+bombcount=$(sed 's/[^0-9]//g' /tmp/bomb.count)
+
+# If we have less process than the process limit, the test must pass.
+if [ $bombcount -le 100 ]; then
+    echo "Done"
+fi

--- a/vm/init.c
+++ b/vm/init.c
@@ -239,7 +239,7 @@ static void launch(char *cmd, uid_t uid) {
         die("fork", NULL);
     } else if(pid > 0) {
         // Parent
-        wait(&status);
+        waitpid(pid, &status, 0);
         if(uid == UID_MASTER &&
                 (!WIFEXITED(status) || WEXITSTATUS(status) != 0))
             shutdown();

--- a/vm/init.c
+++ b/vm/init.c
@@ -30,7 +30,7 @@
 #include <sys/shm.h>
 #include <sys/sem.h>
 #include <sys/msg.h>
-#include <linux/reboot.h>
+#include <sys/reboot.h>
 
 #define LOGNAME "pythia"
 
@@ -56,7 +56,7 @@
  * Shut down the virtual machine.
  */
 static inline void shutdown() {
-    reboot(LINUX_REBOOT_CMD_HALT);
+    reboot(RB_HALT_SYSTEM);
 }
 
 /**


### PR DESCRIPTION
This PR also contains a little fix to remove a compilation warning.
