### PR TITLE
Minor change 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
 
 script:
     # Build everything and test with go1.2
-    - gvm use go1.2 && make all gotest
+    - gvm use go1.2 && make all check
     # Test with go1.4
-    - rm out/pythia && rm -r go/pkg go/bin && gvm use go1.4 && make go gotest
+    - rm out/pythia && rm -r go/pkg go/bin && gvm use go1.4 && make go check
     # Test with go1.6
-    - rm out/pythia && rm -r go/pkg go/bin && gvm use go1.6 && make go gotest
+    - rm out/pythia && rm -r go/pkg go/bin && gvm use go1.6 && make go check
 
 addons:
     apt:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Pythia is an application that executes code safely, within UML virtual machines.
 
 - Make 4.0 or later
 - Go 1.2.1 or later
+- Squashfs
+- gcc-multilib
+- fakeroot
+- bc
 
 ## Quick Install
 


### PR DESCRIPTION
There is two changes:
- Update the requirements dependencies to build and run pythia
- Change the test method in Travis. We no longer use gotest. We should use "make check" that performs all the pythia plateforms tests and not just the go related test.
