### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,6 @@ RUN apt-get update \
 RUN apt-get update \
 	&& apt-get install -y fakeroot squashfs-tools libc6-dev-i386 bc
 
-#Install make4
-
-WORKDIR /home/
-RUN curl http://gnu.xl-mirror.nl/make/make-4.1.tar.gz | tar -v -C . -xz
-WORKDIR /home/make-4.1/
-RUN ./configure && make && make install &&make distclean
-
 #Install Pythia
 
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN ./configure && make && make install &&make distclean
 #Install Pythia
 
 WORKDIR /home
-RUN git clone https://github.com/pythia-project/pythia-core.git
+RUN git clone https://github.com/pythia-project/pythia-core.git pythia
 RUN ls && pwd
 WORKDIR /home/pythia/
 RUN git submodule update --init --recursive && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Virginie Van den Schrieck, virginie.vandenschrieck@pythia-project.org
 RUN cat /etc/resolv.conf
 RUN apt-get update  \
 		&& apt-get install -y gcc libc6-dev make curl wget xz-utils\
-			--no-install-recommends \
+               ca-certificates bzip2 --no-install-recommends \
 		&& rm -rf /var/lib/apt/lists/*
 
 
@@ -37,8 +37,7 @@ RUN apt-get update \
 
 RUN apt-get update \
 	&& apt-get install -y fakeroot squashfs-tools libc6-dev-i386 bc
-	
-	
+
 #Install make4
 
 WORKDIR /home/
@@ -49,7 +48,7 @@ RUN ./configure && make && make install &&make distclean
 #Install Pythia
 
 WORKDIR /home
-RUN git clone https://github.com/pythia-project/pythia.git 
+RUN git clone https://github.com/pythia-project/pythia.git
 RUN ls && pwd
 WORKDIR /home/pythia/
 RUN git submodule update --init --recursive && make
@@ -59,6 +58,4 @@ RUN git submodule update --init --recursive && make
 RUN echo "tmpfs /dev/shm tmpfs defaults,nosuid,nodev 0 0" >> /etc/fstab && echo "">>/etc/fstab
 
 #TODO manually when running in privileged mode : mount /dev/shm
-
- 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN ./configure && make && make install &&make distclean
 #Install Pythia
 
 WORKDIR /home
-RUN git clone https://github.com/pythia-project/pythia.git
+RUN git clone https://github.com/pythia-project/pythia-core.git
 RUN ls && pwd
 WORKDIR /home/pythia/
 RUN git submodule update --init --recursive && make

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ Once successfully installed, you can try to execute a simple task:
 
 and you will see, among others, ``Hello world!`` printed in your terminal.
 
+## Use with Docker
+Docker allow the pythia-core framework to run on MacOS or Windows installation.
+
+Start by cloning the git repository and build the docker image:
+
+    > git clone --recursive https://github.com/pythia-project/pythia-core.git
+    > cd pythia-core
+    > docker build -t pythia-core .
+    
+Once the image is successfully built, you can now start the image:
+
+    > docker run -dit -p 8080:8080 --security-opt seccomp:unconfined --privileged pythia-core
+    > docker exec -it --privileged CONTAINER_ID bash
+    > mount /dev/shm
+    > cd out && touch input.txt
+    > ./pythia execute -input="input.txt" -tasks="tasks/hello-world.task"
+    
+You can obtain the container id using docker ps.
+You should see among others, ``Hello world!`` printed in your terminal.
+
 ## Contributors
 
 - Sébastien Combéfis


### PR DESCRIPTION
The current Ubuntu version used by the Dockerfile is not providing an up-to-date CA certs database leading to an impossibility to resolve HTTPS secured domain.

I solved this by :
- Add ca-certificates as a dependency to update the CA certs database to allow
HTTPS resolution (required to clone with git and wget the busybx

The downloaded busybox is currently on bzip2 archive format which is not supported without a dependency on Ubuntu docker image.

I solved this by :
- Add bzip2 as a dependency to decompress the busybox bzip2 archive